### PR TITLE
Two finger movement of map enforced on mobile only

### DIFF
--- a/script.js
+++ b/script.js
@@ -23,7 +23,8 @@ $(document).ready(function () {
     /*
         Map
     */
-    var mymap = L.map('mapid').setView([46.2512, -63.1350], 13);
+
+    var mymap = L.map('mapid', { dragging: !L.Browser.mobile }).setView([46.2512, -63.1350], 13);
 
     // limit zoom level since Charlottetown is not that large
     mymap.options.minZoom = 12;
@@ -51,7 +52,7 @@ $(document).ready(function () {
         },
 
     });
-    
+
     var legend = L.control({position: 'bottomright'});
 
     legend.onAdd = function (mymap) {
@@ -97,7 +98,7 @@ $(document).ready(function () {
         maxZoom: 18,
         attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
     }).addTo(mymap);
-    
+
     globalMap = mymap;
     // disable clustering once zoomed in close enough
     var markers = L.markerClusterGroup({ disableClusteringAtZoom: 15 });
@@ -177,7 +178,7 @@ function highlightFeature(e) {
     if (!L.Browser.ie && !L.Browser.opera && !L.Browser.edge) {
         layer.bringToFront();
     }
-    
+
     globalInfo.update(layer.feature.properties);
 }
 
@@ -386,10 +387,10 @@ function ajax(params) {
             document.getElementById("hum_avg").innerHTML = "Average: " + calcAverage(modifiedJSON, "Humidity") + "%";
             document.getElementById("hum_max").innerHTML = "Maximum: " + calcMax(modifiedJSON, "Humidity") + "%";
             document.getElementById("hum_min").innerHTML = "Minimum: " + calcMin(modifiedJSON, "Humidity") + "%";
-            
+
             sensors = modifiedJSON;
             var map = globalMap;
-            
+
             var all_sensors = L.geoJSON(sensors, {
                 onEachFeature: function (feature, layer) {
                     layer.setIcon(grapes_small);
@@ -398,10 +399,10 @@ function ajax(params) {
                     );
                 }
             });
-            
+
             var markers = L.markerClusterGroup({ disableClusteringAtZoom: 1 });
             map.removeLayer(globalLayer);
-            
+
             markers.addLayer(all_sensors);
             globalLayer = markers;
             map.addLayer(markers);
@@ -419,15 +420,15 @@ function ajax(params) {
 
             // Get the polygons
             var voronoiPolygons = turf.voronoi(sensors, options);
-            
+
             for(var i = 0; i < sensors.features.length; i++) {
                 sensors.features[i].geometry = voronoiPolygons.features[i].geometry;
             }
-            
+
             if(globalGeoJSON != null) {
                 map.removeLayer(globalGeoJSON);
             }
-            
+
             // Draw the polygons on the map
             globalGeoJSON = L.geoJSON(sensors, {style: style, onEachFeature: onEachFeature});
             map.addLayer(globalGeoJSON);


### PR DESCRIPTION
If on desktop, can still click and drag, but when on mobile now you must use two fingers to move the map around. One finger scrolling will only scroll the website up and down. This did not require an external library like I expected, but instead uses a built in feature of leaflet.